### PR TITLE
Fix use of depcreated  `o.htmlWebpackPlugin.assets` in favor of `o.htmlWebpackPlugin.files`

### DIFF
--- a/conf/tmpl.html
+++ b/conf/tmpl.html
@@ -10,6 +10,8 @@
   <body>
     <div id="app"></div>
 
-    <script src="{%=o.htmlWebpackPlugin.assets.main%}"></script>
+    {% for (var chunk in o.htmlWebpackPlugin.files.chunks) { %}
+    <script src="{%=o.htmlWebpackPlugin.files.chunks[chunk].entry %}"></script>
+    {% } %}
   </body>
 </html>


### PR DESCRIPTION
[This commit](https://github.com/ampedandwired/html-webpack-plugin/commit/ce279debd525105f764250224c5c5e99791cb180) in html-webpack-plugin deprecated the use of `o.htmlWebpackPlugin.assets` in favor of `o.htmlWebpackPlugin.files`.

The accompanying confusing error message  `Error in undefined` has been fixed in [this commit](https://github.com/ampedandwired/html-webpack-plugin/commit/8646d911d0e6c3ee013def047b1e41c030ec091d), but has not been pushed to npm yet.
