### PR TITLE
Overhauling CSS loading in examples to use local scope

### DIFF
--- a/app/components/Application/__tests__/index.js
+++ b/app/components/Application/__tests__/index.js
@@ -1,5 +1,6 @@
 import React from 'react/addons';
 import Application from '../index.jsx';
+import styles from '../style.sass';
 
 describe('Application', function() {
   it('displays the component', function() {
@@ -9,7 +10,7 @@ describe('Application', function() {
       <Application />
     );
 
-    const divs = TestUtils.scryRenderedDOMComponentsWithClass(application, 'ApplicationComponent');
+    const divs = TestUtils.scryRenderedDOMComponentsWithClass(application, styles.main);
 
     expect(divs.length).to.equal(1);
   });

--- a/app/components/Application/index.jsx
+++ b/app/components/Application/index.jsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import Header from '../Header';
 
-/*
-  Component specific stylesheet
-  Can also use .less, .scss, or plain .css files here
-*/
-require('./style.sass');
+/**
+ * Import locally scoped styles using css-loader
+ * See style.sass in this directory.
+ *
+ * More info: https://github.com/webpack/css-loader#local-scope
+ */
+import styles from './style';
 
 export default class Application extends React.Component {
   render() {
-    return <div className="ApplicationComponent">
-      <div className="ApplicationComponent-wrap">
+    return <div className={styles.main}>
+      <div className={styles.wrap}>
         <Header />
 
-        <main className="ApplicationComponent-body">
+        <main className={styles.body}>
           <p>Seems like creating your own React starter kit is a right of passage. So, here's mine.</p>
           <p>For more information, see the <a href="https://github.com/bradleyboy/yarsk#yarsk">Readme</a>.</p>
         </main>

--- a/app/components/Application/style.sass
+++ b/app/components/Application/style.sass
@@ -1,4 +1,4 @@
-.ApplicationComponent
+:local(.main)
   background-image: url(./images/bg.jpg)
   background-size: cover
   background-position: center
@@ -10,7 +10,7 @@
   width: 100%
   height: 100%
 
-.ApplicationComponent-wrap
+:local(.wrap)
   width: 500px
   background: rgba(white, .95)
   padding: 1em
@@ -18,7 +18,7 @@
   box-shadow: 0 0 20px rgba(black, .1)
 
 
-.ApplicationComponent-body
+:local(.body)
   line-height: 1.4em
 
   p

--- a/app/components/Header/__tests__/index.js
+++ b/app/components/Header/__tests__/index.js
@@ -1,5 +1,6 @@
 import React from 'react/addons';
 import Header from '../index.jsx';
+import styles from '../style.sass';
 
 describe('Header', function() {
   it('displays the title', function() {
@@ -9,7 +10,7 @@ describe('Header', function() {
       <Header />
     );
 
-    const title = TestUtils.findRenderedDOMComponentWithClass(header, 'HeaderComponent-title');
+    const title = TestUtils.findRenderedDOMComponentWithClass(header, styles.title);
     const dom = React.findDOMNode(title);
 
     expect(dom.textContent).to.equal('YARSK');

--- a/app/components/Header/index.jsx
+++ b/app/components/Header/index.jsx
@@ -1,25 +1,34 @@
 import React from 'react';
 
-/*
-  Component specific stylesheet
-  Can also use .less, .scss, or plain .css files here
-*/
-require('./style.sass');
+/**
+ * Import locally scoped styles using css-loader
+ * See style.sass in this directory.
+ *
+ * More info: https://github.com/webpack/css-loader#local-scope
+ */
+import styles from './style';
 
-/*
-  Reference an image and get back a URL automatically via webpack.
-  webpack takes care of versioning, bundling for production, etc.
+/**
+ * Reference an image and get back a URL automatically via webpack.
+ * webpack takes care of versioning, bundling for production, etc.
 */
-const logoURL = require('./images/react-logo.svg');
+import logoURL from './images/react-logo.svg';
 
 export default class Header extends React.Component {
   render() {
-    return <header className="HeaderComponent">
-      <img className="HeaderComponent-logo" src={logoURL} height="125" />
+    return <header className={styles.main}>
+      <img className={styles.logo} src={logoURL} height="125" />
 
-      <div className="HeaderComponent-wrap">
-        <h1 className="HeaderComponent-title">YARSK</h1>
-        <h2 className="HeaderComponent-tagline">(<strong>Y</strong>et <strong>A</strong>nother <strong>R</strong>eact <strong>S</strong>tarter <strong>K</strong>it)</h2>
+      <div className={styles.wrap}>
+        <h1 className={styles.title}>YARSK</h1>
+
+        <h2 className={styles.tagline}>
+          (<strong>Y</strong>et{' '}
+            <strong>A</strong>nother{' '}
+            <strong>R</strong>eact{' '}
+            <strong>S</strong>tarter{' '}
+            <strong>K</strong>it)
+        </h2>
       </div>
     </header>;
   }

--- a/app/components/Header/style.sass
+++ b/app/components/Header/style.sass
@@ -1,22 +1,22 @@
-.HeaderComponent
+:local(.main)
   display: flex
   padding-bottom: 1em
   border-bottom: 1px solid #eee
   margin-bottom: 1em
 
-.HeaderComponent-logo
+:local(.logo)
   margin-right: 20px
 
-.HeaderComponent-wrap
+:local(.wrap)
   display: flex
   flex-flow: column
   justify-content: center
 
-.HeaderComponent-title
+:local(.title)
   margin-bottom: .5em
   font-weight: bold
   font-size: 2em
 
-.HeaderComponent-tagline
+:local(.tagline)
   strong
     font-weight: bold

--- a/app/css/base.sass
+++ b/app/css/base.sass
@@ -1,4 +1,4 @@
-@import reset.css
+@import reset
 
 *
   box-sizing: border-box

--- a/app/css/reset.sass
+++ b/app/css/reset.sass
@@ -1,7 +1,6 @@
 /* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
-   License: none (public domain)
-*/
+   License: none (public domain) */
 
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -15,34 +14,33 @@ table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-}
+time, mark, audio, video
+  margin: 0
+  padding: 0
+  border: 0
+  font-size: 100%
+  font: inherit
+  vertical-align: baseline
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
+footer, header, hgroup, menu, nav, section
+  display: block
+
+body
+  line-height: 1
+
+ol, ul
+  list-style: none
+
+blockquote, q
+  quotes: none
+
 blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
+q:before, q:after
+  content: ''
+  content: none
+
+table
+  border-collapse: collapse
+  border-spacing: 0

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,6 +1,6 @@
 // IMPORTANT: This needs to be first (before any other components)
 // to get around CSS order randomness in webpack.
-require('./css/base.sass');
+import './css/base';
 
 // Some ES6+ features require the babel polyfill
 // More info here: https://babeljs.io/docs/usage/polyfill/

--- a/conf/make-webpack-config.js
+++ b/conf/make-webpack-config.js
@@ -87,7 +87,7 @@ module.exports = function(options) {
       ],
     },
     resolve: {
-      extensions: ['', '.js', '.jsx'],
+      extensions: ['', '.js', '.jsx', '.sass', '.scss', '.less', '.css'],
     },
     plugins: options.production ? [
       // Important to keep React file size down

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "react": "~0.13.0"
   },
   "devDependencies": {
-    "autoprefixer-loader": "^1.2.0",
+    "autoprefixer-loader": "^2.0.0",
     "babel": "^5.1.10",
     "babel-core": "^4.7.8",
     "babel-eslint": "^2.0.2",
     "babel-loader": "^5.0.0",
-    "css-loader": "^0.9.1",
+    "css-loader": "^0.14.0",
     "eslint": "^0.17.1",
     "eslint-loader": "^0.7.0",
     "extract-text-webpack-plugin": "^0.3.8",
@@ -43,8 +43,8 @@
     "less": "^2.4.0",
     "less-loader": "^2.1.0",
     "react-hot-loader": "^1.2.3",
-    "sass-loader": "^0.4.2",
-    "style-loader": "^0.8.3",
+    "sass-loader": "^1.0.0",
+    "style-loader": "^0.12.0",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.7.0"


### PR DESCRIPTION
css-loader recently added the ability to use scoped identifiers, which
makes created self-contained components much easier. More info at the
links below:

https://github.com/webpack/css-loader#local-scope
https://medium.com/seek-ui-engineering/the-end-of-global-css-90d2a4a0628
4
