### PR TITLE
upgrade to react v0.14, fix react-hot-loader

### DIFF
--- a/app/components/Application/__tests__/index.js
+++ b/app/components/Application/__tests__/index.js
@@ -1,16 +1,15 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 import Application from '../index.jsx';
 import styles from '../style.sass';
 
 describe('Application', function() {
   it('displays the component', function() {
-    const TestUtils = React.addons.TestUtils;
-
-    const application = TestUtils.renderIntoDocument(
+    const application = ReactTestUtils.renderIntoDocument(
       <Application />
     );
 
-    const divs = TestUtils.scryRenderedDOMComponentsWithClass(application, styles.main);
+    const divs = ReactTestUtils.scryRenderedDOMComponentsWithClass(application, styles.main);
 
     expect(divs.length).to.equal(1);
   });

--- a/app/components/Header/__tests__/index.js
+++ b/app/components/Header/__tests__/index.js
@@ -1,17 +1,17 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
 import Header from '../index.jsx';
 import styles from '../style.sass';
 
 describe('Header', function() {
   it('displays the title', function() {
-    const TestUtils = React.addons.TestUtils;
-
-    const header = TestUtils.renderIntoDocument(
+    const header = ReactTestUtils.renderIntoDocument(
       <Header />
     );
 
-    const title = TestUtils.findRenderedDOMComponentWithClass(header, styles.title);
-    const dom = React.findDOMNode(title);
+    const title = ReactTestUtils.findRenderedDOMComponentWithClass(header, styles.title);
+    const dom = ReactDOM.findDOMNode(title);
 
     expect(dom.textContent).to.equal('YARSK');
   });

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -8,6 +8,7 @@ import './css/base';
 // require("babel/polyfill");
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Application from './components/Application';
 
-React.render(<Application />, document.getElementById('app'));
+ReactDOM.render(<Application />, document.getElementById('app'));

--- a/conf/make-webpack-config.js
+++ b/conf/make-webpack-config.js
@@ -26,7 +26,11 @@ module.exports = function(options) {
   var jsLoaders = ['babel'];
 
   return {
-    entry: './app/index.jsx',
+    entry: options.production ? './app/index.jsx' : [
+      'webpack-dev-server/client?http://localhost:8080',
+      'webpack/hot/only-dev-server',
+      './app/index.jsx',
+    ],
     debug: !options.production,
     devtool: options.devtool,
     output: {

--- a/conf/make-webpack-config.js
+++ b/conf/make-webpack-config.js
@@ -23,7 +23,9 @@ module.exports = function(options) {
     lessLoaders = extractForProduction(lessLoaders);
   }
 
-  var jsLoaders = ['babel'];
+  var jsLoaders = options.production ?
+    ['babel?optional[]=optimisation.react.inlineElements&optional[]=optimisation.react.constantElements'] :
+    ['babel'];
 
   return {
     entry: options.production ? './app/index.jsx' : [

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
   "name": "yarsk",
   "version": "1.0.0",
-  "description": "My React starter kit. Webpack, Babel, Sass, React 0.13 and more.",
+  "description": "My React starter kit. Webpack, Babel, Sass, React 0.14 and more.",
   "main": "app/index.js",
   "scripts": {
     "test": "./node_modules/karma/bin/karma start conf/karma.conf.js --single-run",
     "test:watch": "./node_modules/karma/bin/karma start conf/karma.conf.js",
     "test:coverage": "./node_modules/karma/bin/karma start conf/karma.coverage.conf.js --single-run",
     "test:ci": "./node_modules/karma/bin/karma start conf/karma.ci.conf.js --single-run",
-    "start": "./node_modules/.bin/webpack-dev-server --config conf/webpack.config.js --hot --progress --colors --inline --content-base ./build",
+    "start": "./node_modules/.bin/webpack-dev-server --config conf/webpack.config.js --hot --progress --colors --content-base ./build",
     "build": "./node_modules/.bin/webpack --config conf/webpack.production.js",
     "build:gh": "npm run build && node ./build-gh-pages.js && rm -r ./dist"
   },
   "author": "Brad Daily <brad@bradleyboy.com>",
   "license": "MIT",
   "dependencies": {
-    "react": "~0.13.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^2.0.0",
@@ -42,6 +43,7 @@
     "karma-webpack": "^1.5.0",
     "less": "^2.4.0",
     "less-loader": "^2.1.0",
+    "react-addons-test-utils": "^0.14.0",
     "react-hot-loader": "^1.2.3",
     "sass-loader": "^1.0.0",
     "style-loader": "^0.12.0",


### PR DESCRIPTION
divided `react` into `react`, `react-dom` and `react-addons-test-utils` according to the v0.14 upgrade guide
modified webpack's `entry` configuration and removed `--inline` flag from `npm start` which will block react-hot-loader.
